### PR TITLE
Allow url parameter to be a function which returns the url to connect to

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,14 @@ var ws = new RobustWebSocket('ws://echo.websocket.org/', null {
 })
 ```
 
+The URL parameter can either be a string, or a function which returns a string. This can be useful if you need the WebSocket to reconnect to a different URL than it connected to initially:
+
+```javascript
+var ws = new RobustWebSocket((ws) => {
+  return ws.reconnects > 0 ? `ws://echo.websocket.org/?reconnect=${ws.reconnects}` : `ws://echo.websocket.org/`
+});
+```
+
 #### `shouldReconnect` Examples
 
 Reconnect with an exponetial backoff on all errors

--- a/robust-websocket.js
+++ b/robust-websocket.js
@@ -145,8 +145,9 @@
     })
 
     function newWebSocket() {
+      var newUrl = (typeof url === 'function' ? url(self) : url);
       pendingReconnect = null
-      realWs = new WebSocket(url, protocols || undefined)
+      realWs = new WebSocket(newUrl, protocols || undefined)
       realWs.binaryType = self.binaryType
 
       attempts++


### PR DESCRIPTION
I'm working on a project with a requirement to reconnect to a different WebSocket URL than the initial connection was to. This is a small change to allow the URL parameter to be a function which returns the URL to connect to. The original usage of passing the URL as a string is still valid.