### PR TITLE
Add TypeScript definition; allow url argument to be an async function

### DIFF
--- a/robust-websocket.d.ts
+++ b/robust-websocket.d.ts
@@ -1,6 +1,6 @@
 declare module 'robust-websocket' {
   export default class RobustWebSocket extends WebSocket {
-    constructor(streamUri: string | (() => string), options?: {
+    constructor(streamUri: string | (() => string | Promise<string>), options?: {
       timeout?: number;
       shouldReconnect?: (event: CloseEvent, ws: WebSocket) => any;
       automaticOpen?: boolean;

--- a/robust-websocket.d.ts
+++ b/robust-websocket.d.ts
@@ -1,0 +1,10 @@
+declare module 'robust-websocket' {
+  export default class RobustWebSocket extends WebSocket {
+    constructor(streamUri: string | (() => string), options?: {
+      timeout?: number;
+      shouldReconnect?: (event: CloseEvent, ws: WebSocket) => any;
+      automaticOpen?: boolean;
+      ignoreConnectivityEvents?: boolean;
+    });
+  }
+}

--- a/robust-websocket.js
+++ b/robust-websocket.js
@@ -144,8 +144,8 @@
       enumerable: true
     })
 
-    function newWebSocket() {
-      var newUrl = (typeof url === 'function' ? url(self) : url);
+    async function newWebSocket() {
+      var newUrl = (typeof url === 'function' ? await url(self) : url);
       pendingReconnect = null
       realWs = new WebSocket(newUrl, protocols || undefined)
       realWs.binaryType = self.binaryType


### PR DESCRIPTION
The PR consists two changes:

- TypeScript support. This is a today's must-have.
- Async function to be supported as URL argument. The reason is that some APIs require to request a renewable key to be used as part of WS URI. For example [Binance API](https://binance-docs.github.io/apidocs/futures/en/#user-data-streams) requires a POST request to be made to get listenKey string. This is what the code looks like (pasted from a project I work on) after the change:

```ts
  const stream = new RobustWebSocket(async function getUrl(): Promise<string> {
      try {
        const { listenKey } = await api.futuresUserDataStream('POST');
        return `${options.accountStreamURL}${listenKey}`;
      } catch (e) {
        console.error(e);
        await delay(5_000);

        return getUrl();
      }
    });
```

I have published the change on NPM to use the library while this PR is waiting to be approved: https://www.npmjs.com/package/altamoon-robust-websocket. 

Thank you for your work!